### PR TITLE
Switch CodeQL to run on Windows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Switched the CodeQL GitHub Action to run on Windows instead of Ubuntu, which makes it run successfully.
Tested by running the action on a forked repo: https://github.com/matushorvath/NovaTrakt/actions/runs/1095881927